### PR TITLE
Adds scroll position indicators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /.env*
 /.pnp*
 /.sass-cache
+/.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log

--- a/README.md
+++ b/README.md
@@ -26,13 +26,18 @@ Usage
 `has-scrolled` modifier accepts two positional arguments:
 
 - `direction`: tracks scroll direction. Possible values are 'vertical', 'horizontal'
-- `callback`: will be called when scroll event happened. A boolean argument will be passed which indicates if the element was scrolled in the specified direction.
+- `callback`: will be called when scroll event happened. A string argument will be passed which indicates how far the element was scrolled in the specified direction. Possible values are:
+
+  - `start`
+  - `middle`
+  - `end`
+  - `none` (when element isn't scrollable)
 
 
 Contributing
 ------------------------------------------------------------------------------
 
-See the [Contributing](CONTRIBUTING.md) guide for details.
+PRs are welcome.
 
 
 License

--- a/tests/integration/modifiers/has-scrolled-test.js
+++ b/tests/integration/modifiers/has-scrolled-test.js
@@ -6,6 +6,34 @@ import { module, test } from 'qunit';
 module('Integration | Modifier | has-scrolled', function (hooks) {
   setupRenderingTest(hooks);
 
+  test('returns start when not scrolled', async function (assert) {
+    await render(hbs`
+      <div
+        id="scroll-container"
+        style="height: 10px; overflow-y: scroll;"
+        {{has-scrolled "vertical" (fn (mut this.hasScrolled))}}
+      >
+        <div style="height: 20px">&nbsp;</div>
+      </div>`);
+
+    assert.equal(this.hasScrolled, 'start', 'scroll is at the start');
+  });
+
+  test('returns middle when scrolled halfway', async function (assert) {
+    await render(hbs`
+      <div
+        id="scroll-container"
+        style="height: 10px; overflow-y: scroll;"
+        {{has-scrolled "vertical" (fn (mut this.hasScrolled))}}
+      >
+        <div style="height: 20px">&nbsp;</div>
+      </div>`);
+
+    await scrollTo('#scroll-container', 0, 5);
+
+    assert.equal(this.hasScrolled, 'middle', 'scroll is at the middle');
+  });
+
   test('react to vertical scrolling', async function (assert) {
     await render(hbs`
       <div
@@ -16,9 +44,13 @@ module('Integration | Modifier | has-scrolled', function (hooks) {
         <div style="height: 20px">&nbsp;</div>
       </div>`);
 
-    await scrollTo('#scroll-container', 0, 100);
+    await scrollTo('#scroll-container', 0, 10);
 
-    assert.true(this.hasScrolled, 'scrolling reflected in the variable');
+    assert.equal(
+      this.hasScrolled,
+      'end',
+      'scrolling reflected in the variable'
+    );
   });
 
   test('react to horizontal scrolling', async function (assert) {
@@ -31,9 +63,13 @@ module('Integration | Modifier | has-scrolled', function (hooks) {
         <div style="width: 20px">&nbsp;</div>
       </div>`);
 
-    await scrollTo('#scroll-container', 100, 0);
+    await scrollTo('#scroll-container', 10, 0);
 
-    assert.true(this.hasScrolled, 'scrolling reflected in the variable');
+    assert.equal(
+      this.hasScrolled,
+      'end',
+      'scrolling reflected in the variable'
+    );
   });
 
   test('react to scrolling container resize', async function (assert) {
@@ -56,11 +92,12 @@ module('Integration | Modifier | has-scrolled', function (hooks) {
     elementToRemove.remove();
 
     setTimeout(() => {
-      assert.false(
+      assert.equal(
         this.hasScrolled,
+        'none',
         'updates the variable when scrolling container is resized'
       );
       done();
-    }, 50);
+    }, 100);
   });
 });


### PR DESCRIPTION
The modifier now returns string values which indicates how far the element was scrolled: `start`, `middle`, `end`, `none`.