### PR TITLE
Change API to return a hash of booleans

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Usage
 
 `has-scrolled` modifier accepts two positional arguments:
 
-- `direction`: tracks scroll direction. Possible values are 'vertical', 'horizontal'
-- `callback`: will be called when scroll event happened. A string argument will be passed which indicates how far the element was scrolled in the specified direction. Possible values are:
+- `direction`: tracks scroll direction. Possible values are 'vertical', 'horizontal'.
+- `callback`: will be called when scroll event happened. An object will be passed as an argument with two boolean values:
 
-  - `start`
-  - `middle`
-  - `end`
-  - `none` (when element isn't scrollable)
+  - `hasScrolled`: is `true` if the element was scrolled, is `false` otherwise.
+  - `hasRemainingScroll`: is `true` if the element has some scroll left, is `false` otherwise.
+
+Both values are `false` when the element has no scroll.
 
 
 Contributing

--- a/addon/modifiers/has-scrolled.js
+++ b/addon/modifiers/has-scrolled.js
@@ -48,7 +48,7 @@ export default class ScrollPositionModifier extends Modifier {
   handleScroll() {
     const scrollPosition = this.#calculateScrollPosition();
 
-    if (scrollPosition !== this.scrollPosition) {
+    if (this.#isScrollPositionChanged(scrollPosition)) {
       this.scrollPosition = scrollPosition;
       this.callback(scrollPosition);
     }
@@ -66,11 +66,7 @@ export default class ScrollPositionModifier extends Modifier {
   #calculateScrollPosition() {
     const hasScrolled = this.#hasScrolled(this.element);
     const isAtScrollEnd = this.#isAtScrollEnd(this.element);
-    let hasRemainingScroll = true;
-
-    if ((!hasScrolled && isAtScrollEnd) || (hasScrolled && isAtScrollEnd)) {
-      hasRemainingScroll = false;
-    }
+    const hasRemainingScroll = !isAtScrollEnd;
 
     return {
       hasScrolled,
@@ -86,5 +82,18 @@ export default class ScrollPositionModifier extends Modifier {
   #isAtScrollEnd(el) {
     const { scrollSize, clientSize, currentScroll } = this.propertyNames;
     return el[scrollSize] - el[clientSize] - el[currentScroll] <= SCROLL_EDGE;
+  }
+
+  #isScrollPositionChanged({ hasScrolled, hasRemainingScroll }) {
+    const { scrollPosition } = this;
+
+    if (!scrollPosition) {
+      return true;
+    }
+
+    return (
+      scrollPosition.hasScrolled !== hasScrolled ||
+      scrollPosition.hasRemainingScroll !== hasRemainingScroll
+    );
   }
 }

--- a/addon/modifiers/has-scrolled.js
+++ b/addon/modifiers/has-scrolled.js
@@ -64,23 +64,23 @@ export default class ScrollPositionModifier extends Modifier {
   }
 
   #calculateScrollPosition() {
-    const isAtScrollStart = this.#isAtScrollStart(this.element);
+    const hasScrolled = this.#hasScrolled(this.element);
     const isAtScrollEnd = this.#isAtScrollEnd(this.element);
+    let hasRemainingScroll = true;
 
-    if (isAtScrollStart && isAtScrollEnd) {
-      return 'none';
-    } else if (isAtScrollStart) {
-      return 'start';
-    } else if (isAtScrollEnd) {
-      return 'end';
-    } else {
-      return 'middle';
+    if ((!hasScrolled && isAtScrollEnd) || (hasScrolled && isAtScrollEnd)) {
+      hasRemainingScroll = false;
     }
+
+    return {
+      hasScrolled,
+      hasRemainingScroll,
+    };
   }
 
-  #isAtScrollStart(el) {
+  #hasScrolled(el) {
     const { currentScroll } = this.propertyNames;
-    return el[currentScroll] <= SCROLL_EDGE;
+    return el[currentScroll] > SCROLL_EDGE;
   }
 
   #isAtScrollEnd(el) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-has-scrolled-modifier",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Ember has-scrolled modifier",
   "keywords": [
     "ember-addon",

--- a/tests/integration/modifiers/has-scrolled-test.js
+++ b/tests/integration/modifiers/has-scrolled-test.js
@@ -11,12 +11,14 @@ module('Integration | Modifier | has-scrolled', function (hooks) {
       <div
         id="scroll-container"
         style="height: 10px; overflow-y: scroll;"
-        {{has-scrolled "vertical" (fn (mut this.hasScrolled))}}
+        {{has-scrolled "vertical" (fn (mut this.scrollPosition))}}
       >
         <div style="height: 20px">&nbsp;</div>
       </div>`);
 
-    const { hasScrolled, hasRemainingScroll } = this.hasScrolled;
+    await scrollTo('#scroll-container', 0, 0);
+
+    const { hasScrolled, hasRemainingScroll } = this.scrollPosition;
 
     assert.false(
       hasScrolled,
@@ -33,14 +35,14 @@ module('Integration | Modifier | has-scrolled', function (hooks) {
       <div
         id="scroll-container"
         style="height: 10px; overflow-y: scroll;"
-        {{has-scrolled "vertical" (fn (mut this.hasScrolled))}}
+        {{has-scrolled "vertical" (fn (mut this.scrollPosition))}}
       >
         <div style="height: 20px">&nbsp;</div>
       </div>`);
 
     await scrollTo('#scroll-container', 0, 5);
 
-    const { hasScrolled, hasRemainingScroll } = this.hasScrolled;
+    const { hasScrolled, hasRemainingScroll } = this.scrollPosition;
 
     assert.true(hasScrolled, 'hasScrolled is true when scrolled halfway');
     assert.true(
@@ -54,14 +56,14 @@ module('Integration | Modifier | has-scrolled', function (hooks) {
       <div
         id="scroll-container"
         style="height: 10px; overflow-y: scroll;"
-        {{has-scrolled "vertical" (fn (mut this.hasScrolled))}}
+        {{has-scrolled "vertical" (fn (mut this.scrollPosition))}}
       >
         <div style="height: 20px">&nbsp;</div>
       </div>`);
 
     await scrollTo('#scroll-container', 0, 10);
 
-    const { hasScrolled, hasRemainingScroll } = this.hasScrolled;
+    const { hasScrolled, hasRemainingScroll } = this.scrollPosition;
 
     assert.true(hasScrolled, 'hasScrolled is true when scrolled to end');
     assert.false(
@@ -75,14 +77,14 @@ module('Integration | Modifier | has-scrolled', function (hooks) {
       <div
         id="scroll-container"
         style="width: 10px; overflow-x: scroll;"
-        {{has-scrolled "horizontal" (fn (mut this.hasScrolled))}}
+        {{has-scrolled "horizontal" (fn (mut this.scrollPosition))}}
       >
         <div style="width: 20px">&nbsp;</div>
       </div>`);
 
     await scrollTo('#scroll-container', 10, 0);
 
-    const { hasScrolled, hasRemainingScroll } = this.hasScrolled;
+    const { hasScrolled, hasRemainingScroll } = this.scrollPosition;
 
     assert.true(hasScrolled, 'hasScrolled is true when scrolled to end');
     assert.false(
@@ -99,7 +101,7 @@ module('Integration | Modifier | has-scrolled', function (hooks) {
       <div
         id="scroll-container"
         style="height: 200px; overflow-y: scroll;"
-        {{has-scrolled "vertical" (fn (mut this.hasScrolled))}}
+        {{has-scrolled "vertical" (fn (mut this.scrollPosition))}}
       >
         <div style="height: 100px">&nbsp;</div>
         <div id="remove-me" style="height: 300px">&nbsp;</div>
@@ -111,7 +113,7 @@ module('Integration | Modifier | has-scrolled', function (hooks) {
     elementToRemove.remove();
 
     setTimeout(() => {
-      const { hasScrolled, hasRemainingScroll } = this.hasScrolled;
+      const { hasScrolled, hasRemainingScroll } = this.scrollPosition;
 
       assert.false(hasScrolled, 'hasScrolled is false when there is no scroll');
       assert.false(

--- a/tests/integration/modifiers/has-scrolled-test.js
+++ b/tests/integration/modifiers/has-scrolled-test.js
@@ -6,7 +6,7 @@ import { module, test } from 'qunit';
 module('Integration | Modifier | has-scrolled', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('returns start when not scrolled', async function (assert) {
+  test('when not scrolled', async function (assert) {
     await render(hbs`
       <div
         id="scroll-container"
@@ -16,10 +16,19 @@ module('Integration | Modifier | has-scrolled', function (hooks) {
         <div style="height: 20px">&nbsp;</div>
       </div>`);
 
-    assert.equal(this.hasScrolled, 'start', 'scroll is at the start');
+    const { hasScrolled, hasRemainingScroll } = this.hasScrolled;
+
+    assert.false(
+      hasScrolled,
+      'hasScrolled is false when scroll is at the start'
+    );
+    assert.true(
+      hasRemainingScroll,
+      'hasRemainingScroll is true when scroll is at the start'
+    );
   });
 
-  test('returns middle when scrolled halfway', async function (assert) {
+  test('when scrolled halfway', async function (assert) {
     await render(hbs`
       <div
         id="scroll-container"
@@ -31,10 +40,16 @@ module('Integration | Modifier | has-scrolled', function (hooks) {
 
     await scrollTo('#scroll-container', 0, 5);
 
-    assert.equal(this.hasScrolled, 'middle', 'scroll is at the middle');
+    const { hasScrolled, hasRemainingScroll } = this.hasScrolled;
+
+    assert.true(hasScrolled, 'hasScrolled is true when scrolled halfway');
+    assert.true(
+      hasRemainingScroll,
+      'hasRemainingScroll is true when scrolled halfway'
+    );
   });
 
-  test('react to vertical scrolling', async function (assert) {
+  test('when scrolled to end vertically', async function (assert) {
     await render(hbs`
       <div
         id="scroll-container"
@@ -46,14 +61,16 @@ module('Integration | Modifier | has-scrolled', function (hooks) {
 
     await scrollTo('#scroll-container', 0, 10);
 
-    assert.equal(
-      this.hasScrolled,
-      'end',
-      'scrolling reflected in the variable'
+    const { hasScrolled, hasRemainingScroll } = this.hasScrolled;
+
+    assert.true(hasScrolled, 'hasScrolled is true when scrolled to end');
+    assert.false(
+      hasRemainingScroll,
+      'hasRemainingScroll is false when scrolled to end'
     );
   });
 
-  test('react to horizontal scrolling', async function (assert) {
+  test('when scrolled to end horizontally', async function (assert) {
     await render(hbs`
       <div
         id="scroll-container"
@@ -65,15 +82,17 @@ module('Integration | Modifier | has-scrolled', function (hooks) {
 
     await scrollTo('#scroll-container', 10, 0);
 
-    assert.equal(
-      this.hasScrolled,
-      'end',
-      'scrolling reflected in the variable'
+    const { hasScrolled, hasRemainingScroll } = this.hasScrolled;
+
+    assert.true(hasScrolled, 'hasScrolled is true when scrolled to end');
+    assert.false(
+      hasRemainingScroll,
+      'hasRemainingScroll is false when scrolled to end'
     );
   });
 
   test('react to scrolling container resize', async function (assert) {
-    assert.expect(1);
+    assert.expect(2);
     const done = assert.async();
 
     await render(hbs`
@@ -92,11 +111,14 @@ module('Integration | Modifier | has-scrolled', function (hooks) {
     elementToRemove.remove();
 
     setTimeout(() => {
-      assert.equal(
-        this.hasScrolled,
-        'none',
-        'updates the variable when scrolling container is resized'
+      const { hasScrolled, hasRemainingScroll } = this.hasScrolled;
+
+      assert.false(hasScrolled, 'hasScrolled is false when there is no scroll');
+      assert.false(
+        hasRemainingScroll,
+        'hasRemainingScroll is false when there is no scroll'
       );
+
       done();
     }, 100);
   });


### PR DESCRIPTION
This PR changes the modifier's API. It now returns a hash of boolean values: `hasScrolled` and `hasRemainingScroll`.
